### PR TITLE
api: Remove invalid UTF-8 characters after fetch

### DIFF
--- a/public/api.php
+++ b/public/api.php
@@ -42,9 +42,13 @@ function main(): int
 
 	$st = $pdo->prepare("SELECT id, gd_id, name, size FROM pdf {$where} LIMIT {$limit} OFFSET {$offset}");
 	$st->execute($data);
+	$rows = $st->fetchAll(PDO::FETCH_ASSOC);
+	foreach ($rows as &$p)
+		$p["name"] = mb_convert_encoding($p["name"], "UTF-8", "UTF-8");
+
 	$res = [
 		"num_rows" => (int)$nr[0],
-		"data" => $st->fetchAll(PDO::FETCH_ASSOC)
+		"data" => $rows
 	];
 
 out:


### PR DESCRIPTION
When the name contains an invalid UTF-8 characters, the API fails to
generate JSON string. The encoder says:

  Malformed UTF-8 characters, possibly incorrectly encoded

Fix this by calling mb_convert_encoding() for each name.

Signed-off-by: Ammar Faizi <ammarfaizi2@gnuweeb.org>